### PR TITLE
Fix issue with indexing of PrivateKeySubmitted event

### DIFF
--- a/deployment.js
+++ b/deployment.js
@@ -7,7 +7,7 @@ const TARGET_NETWORK = process.env.TARGET_NETWORK || "blast-sepolia";
 const USE_GRAPH_PROTOCOL = process.env.USE_GRAPH_PROTOCOL == "true" || false;
 
 /** The version that will it'll be deployed as */
-const VERSION = "0.6.5";
+const VERSION = "0.6.6";
 
 /**  Deployments to be deployed to Goldsky
  * otherwise they're deployed to Alchemy Subgraphs */

--- a/src/handleEncryptedMarginalPrice.ts
+++ b/src/handleEncryptedMarginalPrice.ts
@@ -85,8 +85,12 @@ export function handlePrivateKeySubmitted(
   // No need to handle bid decryption, as a separate event is emitted for that
   // To handle an auction lot without bids, we need to handle the PrivateKeySubmitted event
 
+  // Get the module
+  const empModule = EncryptedMarginalPrice.bind(event.address);
+  const auctionHouseAddress = empModule.PARENT();
+
   // Get the auction lot record
-  const lotRecord = getLotRecord(event.address, lotId);
+  const lotRecord = getLotRecord(auctionHouseAddress, lotId);
 
   // Update the EMP lot record
   updateEncryptedMarginalPriceLot(lotRecord, lotId);

--- a/tests/empam-utils.ts
+++ b/tests/empam-utils.ts
@@ -1,6 +1,9 @@
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
-import { BidDecrypted } from "../generated/BatchAuctionHouse/EncryptedMarginalPrice";
+import {
+  BidDecrypted,
+  PrivateKeySubmitted,
+} from "../generated/BatchAuctionHouse/EncryptedMarginalPrice";
 import { newMockEvent } from "./mocks/event";
 
 export function createBidDecryptedEvent(
@@ -38,4 +41,21 @@ export function createBidDecryptedEvent(
   }
 
   return bidDecryptedEvent;
+}
+
+export function createPrivateKeySubmittedEvent(
+  auctionModule: Address,
+  lotId: BigInt,
+): PrivateKeySubmitted {
+  const privateKeySubmittedEvent = changetype<PrivateKeySubmitted>(
+    newMockEvent(auctionModule),
+  );
+
+  privateKeySubmittedEvent.parameters = [];
+
+  privateKeySubmittedEvent.parameters.push(
+    new ethereum.EventParam("lotId", ethereum.Value.fromUnsignedBigInt(lotId)),
+  );
+
+  return privateKeySubmittedEvent;
 }


### PR DESCRIPTION
The module address was being used during lookup of the BatchAuctionLot record, when the BatchAuctionHouse address is required